### PR TITLE
Fixed right click crash on Saplings by adding Null guard to ItemStack

### DIFF
--- a/src/main/java/com/gildedgames/the_aether/blocks/BlockAetherSapling.java
+++ b/src/main/java/com/gildedgames/the_aether/blocks/BlockAetherSapling.java
@@ -53,6 +53,8 @@ public class BlockAetherSapling extends BlockAetherFlower implements IGrowable {
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
         ItemStack stack = player.inventory.getCurrentItem();
+        if(stack == null)
+            return true;
         if (stack.getItem() == ItemsAether.swet_ball || stack.getItem() == ItemsAether.golden_swet_ball || stack.getItem() == ItemsAether.purple_swet_ball) {
         	
         	int rand = (int)(1 + Math.random() * 4);

--- a/src/main/java/com/gildedgames/the_aether/blocks/BlockAetherSapling.java
+++ b/src/main/java/com/gildedgames/the_aether/blocks/BlockAetherSapling.java
@@ -60,13 +60,15 @@ public class BlockAetherSapling extends BlockAetherFlower implements IGrowable {
         	int rand = (int)(1 + Math.random() * 4);
         	if (world.getBlockLightValue(x, y + 1, z) >= 9 && rand == 4) {
         		world.setBlock(x, y, z, BlocksAether.skyroot_log, 0, 0);
+                if (!player.capabilities.isCreativeMode) {
+                    --stack.stackSize;
+                }
+
 				this.growTree(world, x, y, z);
 			}
         }
         
-        if (!player.capabilities.isCreativeMode) {
-			--stack.stackSize;
-		}
+
         
     	return true;
 	}


### PR DESCRIPTION
Fixed #18 